### PR TITLE
Load pretrained model on CPU only machine

### DIFF
--- a/cifar/model.py
+++ b/cifar/model.py
@@ -1,6 +1,7 @@
 import torch.nn as nn
 import torch.utils.model_zoo as model_zoo
 from IPython import embed
+import torch
 from collections import OrderedDict
 
 from utee import misc
@@ -56,12 +57,12 @@ def cifar10(n_channel, pretrained=None):
         model.load_state_dict(state_dict)
     return model
 
-def cifar100(n_channel, pretrained=None):
+def cifar100(n_channel, pretrained=None, cuda=True):
     cfg = [n_channel, n_channel, 'M', 2*n_channel, 2*n_channel, 'M', 4*n_channel, 4*n_channel, 'M', (8*n_channel, 0), 'M']
     layers = make_layers(cfg, batch_norm=True)
     model = CIFAR(layers, n_channel=8*n_channel, num_classes=100)
     if pretrained is not None:
-        m = model_zoo.load_url(model_urls['cifar100'])
+        m = model_zoo.load_url(model_urls['cifar100'], map_location=torch.device("cuda" if cuda else "cpu"))
         state_dict = m.state_dict() if isinstance(m, nn.Module) else m
         assert isinstance(state_dict, (dict, OrderedDict)), type(state_dict)
         model.load_state_dict(state_dict)

--- a/cifar/model.py
+++ b/cifar/model.py
@@ -46,12 +46,12 @@ def make_layers(cfg, batch_norm=False):
             in_channels = out_channels
     return nn.Sequential(*layers)
 
-def cifar10(n_channel, pretrained=None):
+def cifar10(n_channel, pretrained=None, cuda=True)):
     cfg = [n_channel, n_channel, 'M', 2*n_channel, 2*n_channel, 'M', 4*n_channel, 4*n_channel, 'M', (8*n_channel, 0), 'M']
     layers = make_layers(cfg, batch_norm=True)
     model = CIFAR(layers, n_channel=8*n_channel, num_classes=10)
     if pretrained is not None:
-        m = model_zoo.load_url(model_urls['cifar10'])
+        m = model_zoo.load_url(model_urls['cifar10'], map_location=torch.device("cuda" if cuda else "cpu"))
         state_dict = m.state_dict() if isinstance(m, nn.Module) else m
         assert isinstance(state_dict, (dict, OrderedDict)), type(state_dict)
         model.load_state_dict(state_dict)

--- a/cifar/model.py
+++ b/cifar/model.py
@@ -46,7 +46,7 @@ def make_layers(cfg, batch_norm=False):
             in_channels = out_channels
     return nn.Sequential(*layers)
 
-def cifar10(n_channel, pretrained=None, cuda=True)):
+def cifar10(n_channel, pretrained=None, cuda=True):
     cfg = [n_channel, n_channel, 'M', 2*n_channel, 2*n_channel, 'M', 4*n_channel, 4*n_channel, 'M', (8*n_channel, 0), 'M']
     layers = make_layers(cfg, batch_norm=True)
     model = CIFAR(layers, n_channel=8*n_channel, num_classes=10)

--- a/imagenet/alexnet.py
+++ b/imagenet/alexnet.py
@@ -1,5 +1,6 @@
 import torch.nn as nn
 import torch.utils.model_zoo as model_zoo
+import torch
 
 
 __all__ = ['AlexNet', 'alexnet']
@@ -46,8 +47,8 @@ class AlexNet(nn.Module):
         return x
 
 
-def alexnet(pretrained=False, model_root=None, **kwargs):
+def alexnet(pretrained=False, model_root=None, cuda=True, **kwargs):
     model = AlexNet(**kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls['alexnet'], model_root))
+        model.load_state_dict(model_zoo.load_url(model_urls['alexnet'], model_root, map_location=torch.device("cuda" if cuda else "cpu")))
     return model

--- a/imagenet/inception.py
+++ b/imagenet/inception.py
@@ -13,12 +13,12 @@ model_urls = {
 }
 
 
-def inception_v3(pretrained=False, model_root=None, **kwargs):
+def inception_v3(pretrained=False, model_root=None, cuda=True, **kwargs):
     if pretrained:
         if 'transform_input' not in kwargs:
             kwargs['transform_input'] = True
         model = Inception3(**kwargs)
-        misc.load_state_dict(model, model_urls['inception_v3_google'], model_root)
+        misc.load_state_dict(model, model_urls['inception_v3_google'], model_root, cuda)
         return model
 
     return Inception3(**kwargs)

--- a/imagenet/resnet.py
+++ b/imagenet/resnet.py
@@ -143,36 +143,36 @@ class ResNet(nn.Module):
         return x
 
 
-def resnet18(pretrained=False, model_root=None, **kwargs):
+def resnet18(pretrained=False, model_root=None, cuda=True, **kwargs):
     model = ResNet(BasicBlock, [2, 2, 2, 2], **kwargs)
     if pretrained:
-        misc.load_state_dict(model, model_urls['resnet18'], model_root)
+        misc.load_state_dict(model, model_urls['resnet18'], model_root, cuda)
     return model
 
 
-def resnet34(pretrained=False, model_root=None, **kwargs):
+def resnet34(pretrained=False, model_root=None, cuda=True, **kwargs):
     model = ResNet(BasicBlock, [3, 4, 6, 3], **kwargs)
     if pretrained:
-        misc.load_state_dict(model, model_urls['resnet34'], model_root)
+        misc.load_state_dict(model, model_urls['resnet34'], model_root, cuda)
     return model
 
 
-def resnet50(pretrained=False, model_root=None, **kwargs):
+def resnet50(pretrained=False, model_root=None, cuda=True, **kwargs):
     model = ResNet(Bottleneck, [3, 4, 6, 3], **kwargs)
     if pretrained:
-        misc.load_state_dict(model, model_urls['resnet50'], model_root)
+        misc.load_state_dict(model, model_urls['resnet50'], model_root, cuda)
     return model
 
 
-def resnet101(pretrained=False, model_root=None, **kwargs):
+def resnet101(pretrained=False, model_root=None, cuda=True, **kwargs):
     model = ResNet(Bottleneck, [3, 4, 23, 3], **kwargs)
     if pretrained:
-        misc.load_state_dict(model, model_urls['resnet101'], model_root)
+        misc.load_state_dict(model, model_urls['resnet101'], model_root, cuda)
     return model
 
 
-def resnet152(pretrained=False, model_root=None, **kwargs):
+def resnet152(pretrained=False, model_root=None, cuda=True, **kwargs):
     model = ResNet(Bottleneck, [3, 8, 36, 3], **kwargs)
     if pretrained:
-        misc.load_state_dict(model, model_urls['resnet152'], model_root)
+        misc.load_state_dict(model, model_urls['resnet152'], model_root, cuda)
     return model

--- a/imagenet/squeezenet.py
+++ b/imagenet/squeezenet.py
@@ -113,18 +113,18 @@ class SqueezeNet(nn.Module):
         x = self.classifier(x)
         return x.view(x.size(0), self.num_classes)
 
-def squeezenet1_0(pretrained=False, model_root=None, **kwargs):
+def squeezenet1_0(pretrained=False, model_root=None, cuda=True, **kwargs):
     r"""SqueezeNet model architecture from the `"SqueezeNet: AlexNet-level
     accuracy with 50x fewer parameters and <0.5MB model size"
     <https://arxiv.org/abs/1602.07360>`_ paper.
     """
     model = SqueezeNet(version=1.0, **kwargs)
     if pretrained:
-        misc.load_state_dict(model, model_urls['squeezenet1_0'], model_root)
+        misc.load_state_dict(model, model_urls['squeezenet1_0'], model_root, cuda)
     return model
 
 
-def squeezenet1_1(pretrained=False, model_root=None, **kwargs):
+def squeezenet1_1(pretrained=False, model_root=None, cuda=True, **kwargs):
     r"""SqueezeNet 1.1 model from the `official SqueezeNet repo
     <https://github.com/DeepScale/SqueezeNet/tree/master/SqueezeNet_v1.1>`_.
     SqueezeNet 1.1 has 2.4x less computation and slightly fewer parameters
@@ -132,6 +132,6 @@ def squeezenet1_1(pretrained=False, model_root=None, **kwargs):
     """
     model = SqueezeNet(version=1.1, **kwargs)
     if pretrained:
-        misc.load_state_dict(model, model_urls['squeezenet1_1'], model_root)
+        misc.load_state_dict(model, model_urls['squeezenet1_1'], model_root, cuda)
     return model
 

--- a/imagenet/vgg.py
+++ b/imagenet/vgg.py
@@ -1,3 +1,4 @@
+import torch
 import torch.nn as nn
 import torch.utils.model_zoo as model_zoo
 import math
@@ -79,11 +80,11 @@ cfg = {
 }
 
 
-def vgg11(pretrained=False, model_root=None, **kwargs):
+def vgg11(pretrained=False, model_root=None, cuda=True, **kwargs):
     """VGG 11-layer model (configuration "A")"""
     model = VGG(make_layers(cfg['A']), **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls['vgg11'], model_root))
+        model.load_state_dict(model_zoo.load_url(model_urls['vgg11'], model_root, map_location=torch.device("cuda" if cuda else "cpu")))
     return model
 
 
@@ -93,11 +94,11 @@ def vgg11_bn(**kwargs):
     return VGG(make_layers(cfg['A'], batch_norm=True), **kwargs)
 
 
-def vgg13(pretrained=False, model_root=None, **kwargs):
+def vgg13(pretrained=False, model_root=None, cuda=True, **kwargs):
     """VGG 13-layer model (configuration "B")"""
     model = VGG(make_layers(cfg['B']), **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls['vgg13'], model_root))
+        model.load_state_dict(model_zoo.load_url(model_urls['vgg13'], model_root, map_location=torch.device("cuda" if cuda else "cpu")))
     return model
 
 
@@ -107,11 +108,11 @@ def vgg13_bn(**kwargs):
     return VGG(make_layers(cfg['B'], batch_norm=True), **kwargs)
 
 
-def vgg16(pretrained=False, model_root=None, **kwargs):
+def vgg16(pretrained=False, model_root=None, cuda=True, **kwargs):
     """VGG 16-layer model (configuration "D")"""
     model = VGG(make_layers(cfg['D']), **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls['vgg16'], model_root))
+        model.load_state_dict(model_zoo.load_url(model_urls['vgg16'], model_root, map_location=torch.device("cuda" if cuda else "cpu")))
     return model
 
 
@@ -121,11 +122,11 @@ def vgg16_bn(**kwargs):
     return VGG(make_layers(cfg['D'], batch_norm=True), **kwargs)
 
 
-def vgg19(pretrained=False, model_root=None, **kwargs):
+def vgg19(pretrained=False, model_root=None, cuda=True, **kwargs):
     """VGG 19-layer model (configuration "E")"""
     model = VGG(make_layers(cfg['E']), **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls['vgg19'], model_root))
+        model.load_state_dict(model_zoo.load_url(model_urls['vgg19'], model_root, map_location=torch.device("cuda" if cuda else "cpu")))
     return model
 
 

--- a/mnist/model.py
+++ b/mnist/model.py
@@ -2,6 +2,7 @@ import torch.nn as nn
 from collections import OrderedDict
 import torch.utils.model_zoo as model_zoo
 from utee import misc
+import torch
 print = misc.logger.info
 
 model_urls = {
@@ -35,10 +36,10 @@ class MLP(nn.Module):
         assert input.size(1) == self.input_dims
         return self.model.forward(input)
 
-def mnist(input_dims=784, n_hiddens=[256, 256], n_class=10, pretrained=None):
+def mnist(input_dims=784, n_hiddens=[256, 256], n_class=10, pretrained=None, cuda=True):
     model = MLP(input_dims, n_hiddens, n_class)
     if pretrained is not None:
-        m = model_zoo.load_url(model_urls['mnist'])
+        m = model_zoo.load_url(model_urls['mnist'], map_location=torch.device("cuda" if cuda else "cpu"))
         state_dict = m.state_dict() if isinstance(m, nn.Module) else m
         assert isinstance(state_dict, (dict, OrderedDict)), type(state_dict)
         model.load_state_dict(state_dict)

--- a/stl10/model.py
+++ b/stl10/model.py
@@ -44,7 +44,7 @@ def make_layers(cfg, batch_norm=False):
             in_channels = out_channels
     return nn.Sequential(*layers)
 
-def stl10(n_channel, pretrained=None):
+def stl10(n_channel, pretrained=None, cuda=True):
     cfg = [
         n_channel, 'M',
         2*n_channel, 'M',
@@ -55,7 +55,7 @@ def stl10(n_channel, pretrained=None):
     layers = make_layers(cfg, batch_norm=True)
     model = SVHN(layers, n_channel=8*n_channel, num_classes=10)
     if pretrained is not None:
-        m = model_zoo.load_url(model_urls['stl10'])
+        m = model_zoo.load_url(model_urls['stl10'], map_location=torch.device("cuda" if cuda else "cpu"))
         state_dict = m.state_dict() if isinstance(m, nn.Module) else m
         assert isinstance(state_dict, (dict, OrderedDict)), type(state_dict)
         model.load_state_dict(state_dict)

--- a/svhn/model.py
+++ b/svhn/model.py
@@ -44,12 +44,12 @@ def make_layers(cfg, batch_norm=False):
             in_channels = out_channels
     return nn.Sequential(*layers)
 
-def svhn(n_channel, pretrained=None):
+def svhn(n_channel, pretrained=None, cuda=True):
     cfg = [n_channel, n_channel, 'M', 2*n_channel, 2*n_channel, 'M', 4*n_channel, 4*n_channel, 'M', (8*n_channel, 0), 'M']
     layers = make_layers(cfg, batch_norm=True)
     model = SVHN(layers, n_channel=8*n_channel, num_classes=10)
     if pretrained is not None:
-        m = model_zoo.load_url(model_urls['svhn'])
+        m = model_zoo.load_url(model_urls['svhn'], map_location=torch.device("cuda" if cuda else "cpu"))
         state_dict = m.state_dict() if isinstance(m, nn.Module) else m
         assert isinstance(state_dict, (dict, OrderedDict)), type(state_dict)
         model.load_state_dict(state_dict)

--- a/utee/misc.py
+++ b/utee/misc.py
@@ -5,6 +5,7 @@ import pickle as pkl
 import time
 import numpy as np
 import hashlib
+import torch
 
 from IPython import embed
 
@@ -198,7 +199,7 @@ def eval_model(model, ds, n_sample=None, ngpu=1, is_imagenet=False):
     acc5 = correct5 * 1.0 / n_passed
     return acc1, acc5
 
-def load_state_dict(model, model_urls, model_root):
+def load_state_dict(model, model_urls, model_root, cuda=True):
     from torch.utils import model_zoo
     from torch import nn
     import re
@@ -209,7 +210,7 @@ def load_state_dict(model, model_urls, model_root):
         k = re.sub('group\d+\.', '', k)
         own_state[k] = v
 
-    state_dict = model_zoo.load_url(model_urls, model_root)
+    state_dict = model_zoo.load_url(model_urls, model_root, map_location=torch.device("cuda" if cuda else "cpu"))
 
     for name, param in state_dict.items():
         if name not in own_state:

--- a/utee/selector.py
+++ b/utee/selector.py
@@ -18,7 +18,7 @@ known_models = [
 def mnist(cuda=True, model_root=None):
     print("Building and initializing mnist parameters")
     from mnist import model, dataset
-    m = model.mnist(pretrained=os.path.join(model_root, 'mnist.pth'))
+    m = model.mnist(pretrained=os.path.join(model_root, 'mnist.pth'), cuda=cuda)
     if cuda:
         m = m.cuda()
     return m, dataset.get, False
@@ -26,7 +26,7 @@ def mnist(cuda=True, model_root=None):
 def svhn(cuda=True, model_root=None):
     print("Building and initializing svhn parameters")
     from svhn import model, dataset
-    m = model.svhn(32, pretrained=os.path.join(model_root, 'svhn.pth'))
+    m = model.svhn(32, pretrained=os.path.join(model_root, 'svhn.pth'), cuda=cuda)
     if cuda:
         m = m.cuda()
     return m, dataset.get, False
@@ -34,7 +34,7 @@ def svhn(cuda=True, model_root=None):
 def cifar10(cuda=True, model_root=None):
     print("Building and initializing cifar10 parameters")
     from cifar import model, dataset
-    m = model.cifar10(128, pretrained=os.path.join(model_root, 'cifar10.pth'))
+    m = model.cifar10(128, pretrained=os.path.join(model_root, 'cifar10.pth'), cuda=cuda)
     if cuda:
         m = m.cuda()
     return m, dataset.get10, False
@@ -42,7 +42,7 @@ def cifar10(cuda=True, model_root=None):
 def cifar100(cuda=True, model_root=None):
     print("Building and initializing cifar100 parameters")
     from cifar import model, dataset
-    m = model.cifar100(128, pretrained=os.path.join(model_root, 'cifar100.pth'))
+    m = model.cifar100(128, pretrained=os.path.join(model_root, 'cifar100.pth'), cuda=cuda)
     if cuda:
         m = m.cuda()
     return m, dataset.get100, False
@@ -50,7 +50,7 @@ def cifar100(cuda=True, model_root=None):
 def stl10(cuda=True, model_root=None):
     print("Building and initializing stl10 parameters")
     from stl10 import model, dataset
-    m = model.stl10(32, pretrained=os.path.join(model_root, 'stl10.pth'))
+    m = model.stl10(32, pretrained=os.path.join(model_root, 'stl10.pth'), cuda=cuda)
     if cuda:
         m = m.cuda()
     return m, dataset.get, False
@@ -58,7 +58,7 @@ def stl10(cuda=True, model_root=None):
 def alexnet(cuda=True, model_root=None):
     print("Building and initializing alexnet parameters")
     from imagenet import alexnet as alx
-    m = alx.alexnet(True, model_root)
+    m = alx.alexnet(True, model_root, cuda=cuda)
     if cuda:
         m = m.cuda()
     return m, dataset.get, True
@@ -82,7 +82,7 @@ def vgg16_bn(cuda=True, model_root=None):
 def vgg19(cuda=True, model_root=None):
     print("Building and initializing vgg19 parameters")
     from imagenet import vgg
-    m = vgg.vgg19(True, model_root)
+    m = vgg.vgg19(True, model_root, cuda=cuda)
     if cuda:
         m = m.cuda()
     return m, dataset.get, True
@@ -98,7 +98,7 @@ def vgg19_bn(cuda=True, model_root=None):
 def inception_v3(cuda=True, model_root=None):
     print("Building and initializing inception_v3 parameters")
     from imagenet import inception
-    m = inception.inception_v3(True, model_root)
+    m = inception.inception_v3(True, model_root, cuda=cuda)
     if cuda:
         m = m.cuda()
     return m, dataset.get, True
@@ -106,7 +106,7 @@ def inception_v3(cuda=True, model_root=None):
 def resnet18(cuda=True, model_root=None):
     print("Building and initializing resnet-18 parameters")
     from imagenet import resnet
-    m = resnet.resnet18(True, model_root)
+    m = resnet.resnet18(True, model_root, cuda=cuda)
     if cuda:
         m = m.cuda()
     return m, dataset.get, True
@@ -114,7 +114,7 @@ def resnet18(cuda=True, model_root=None):
 def resnet34(cuda=True, model_root=None):
     print("Building and initializing resnet-34 parameters")
     from imagenet import resnet
-    m = resnet.resnet34(True, model_root)
+    m = resnet.resnet34(True, model_root, cuda=cuda)
     if cuda:
         m = m.cuda()
     return m, dataset.get, True
@@ -122,7 +122,7 @@ def resnet34(cuda=True, model_root=None):
 def resnet50(cuda=True, model_root=None):
     print("Building and initializing resnet-50 parameters")
     from imagenet import resnet
-    m = resnet.resnet50(True, model_root)
+    m = resnet.resnet50(True, model_root, cuda=cuda)
     if cuda:
         m = m.cuda()
     return m, dataset.get, True
@@ -130,7 +130,7 @@ def resnet50(cuda=True, model_root=None):
 def resnet101(cuda=True, model_root=None):
     print("Building and initializing resnet-101 parameters")
     from imagenet import resnet
-    m = resnet.resnet101(True, model_root)
+    m = resnet.resnet101(True, model_root, cuda=cuda)
     if cuda:
         m = m.cuda()
     return m, dataset.get, True
@@ -138,7 +138,7 @@ def resnet101(cuda=True, model_root=None):
 def resnet152(cuda=True, model_root=None):
     print("Building and initializing resnet-152 parameters")
     from imagenet import resnet
-    m = resnet.resnet152(True, model_root)
+    m = resnet.resnet152(True, model_root, cuda=cuda)
     if cuda:
         m = m.cuda()
     return m, dataset.get, True
@@ -146,7 +146,7 @@ def resnet152(cuda=True, model_root=None):
 def squeezenet_v0(cuda=True, model_root=None):
     print("Building and initializing squeezenet_v0 parameters")
     from imagenet import squeezenet
-    m = squeezenet.squeezenet1_0(True, model_root)
+    m = squeezenet.squeezenet1_0(True, model_root, cuda=cuda)
     if cuda:
         m = m.cuda()
     return m, dataset.get, True
@@ -154,7 +154,7 @@ def squeezenet_v0(cuda=True, model_root=None):
 def squeezenet_v1(cuda=True, model_root=None):
     print("Building and initializing squeezenet_v1 parameters")
     from imagenet import squeezenet
-    m = squeezenet.squeezenet1_1(True, model_root)
+    m = squeezenet.squeezenet1_1(True, model_root, cuda=cuda)
     if cuda:
         m = m.cuda()
     return m, dataset.get, True


### PR DESCRIPTION
I tried to load pretrained MNIST model on a CPU only machine, however, I met

> RuntimeError: Attempting to deserialize object on a CUDA device but 
>   torch.cuda.is_available() is False. If you are running on a CPU-only machine, 
>   please use torch.load with map_location='cpu' to map your storages to the CPU.

So I added a parameter `cuda` with a default value `True` when creating models. This parameter is only used when loading pretrained models from model_zoo. 

When load model from model_zoo.load_url, I set the `map_location` to "cuda" if cuda=True in the parameter, else "cpu" 
> map_location (optional) – a function or a dict specifying how to remap storage locations (see torch.load)

from https://pytorch.org/docs/stable/model_zoo.html